### PR TITLE
Add test for sending XMR to multiple recipients

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ To send payments to multiple recipients simply use an array of `[:recipient, :am
 
 ```ruby
 recipients = [
-  {address:A7TmpAyaPeZLnugTKRSwGJhW4vnYv8RAVdRvYyvbistbHUnojyTHyHcYpbZvbTZHDsi4rF1EK5TiYgnCN6FWM9HjfwGRvbCHYCZAaKSzDx amount: 1599999},
-  {address:A7TmpAyaPeZLnugTKRSwGJhW4vnYv8RAVdRvYyvbistbHUnojyTHyHcYpbZvbTZHDsi4rF1EK5TiYgnCN6FWM9Hjftr1RgJ6RM4BMMPLUc amount: 130000},
-  {address:A7TmpAyaPeZLnugTKRSwGJhW4vnYv8RAVdRvYyvbistbHUnojyTHyHcYpbZvbTZHDsi4rF1EK5TiYgnCN6FWM9HjfrgPgAEasYGSVhUdwe amount: 442130000}
+  {address:"A7TmpAyaPeZLnugTKRSwGJhW4vnYv8RAVdRvYyvbistbHUnojyTHyHcYpbZvbTZHDsi4rF1EK5TiYgnCN6FWM9HjfwGRvbCHYCZAaKSzDx" amount: 1599999},
+  {address:"A7TmpAyaPeZLnugTKRSwGJhW4vnYv8RAVdRvYyvbistbHUnojyTHyHcYpbZvbTZHDsi4rF1EK5TiYgnCN6FWM9Hjftr1RgJ6RM4BMMPLUc" amount: 130000},
+  {address:"A7TmpAyaPeZLnugTKRSwGJhW4vnYv8RAVdRvYyvbistbHUnojyTHyHcYpbZvbTZHDsi4rF1EK5TiYgnCN6FWM9HjfrgPgAEasYGSVhUdwe" amount: 442130000}
 ]
 
 RPC::Transfer.send_bulk(recipients, options)

--- a/spec/monero_spec.rb
+++ b/spec/monero_spec.rb
@@ -65,12 +65,29 @@ RSpec.describe RPC do
     expect(height).to be_an(Integer)
   end
 
-  # the wallet locks for approx 10 blocks so this test will fail
+  # the wallet locks for approx 10 blocks so this test will fail if
+  # balance is not yet unlocked
   it "sends XMR to a standard address" do
     subaddress = RPC::Wallet.create_address "receiving_wallet"
     amount = 20075
     transfer = RPC::Transfer.create(subaddress['address'], amount)
     expect(transfer['amount']).to eq(amount)
+    expect(transfer['fee']).to be_an(Integer)
+    expect(transfer['multisig_txset']).to be_empty
+    expect(transfer['tx_blob']).to be_empty
+    expect(transfer['tx_hash']).to be_truthy
+    expect(transfer['tx_key']).to be_truthy
+    expect(transfer['tx_metadata']).to be_empty
+    expect(transfer['unsigned_txset']).to be_empty
+  end
+
+  it "sends XMR to multiple recipients" do
+    subaddress1 = RPC::Wallet.create_address "receiving_wallet"
+    subaddress2 = RPC::Wallet.create_address "receiving_wallet2"
+    amount1 = 20075
+    amount2 = 20075
+
+    expect(transfer['amount']).to eq(amount1+amount2)
     expect(transfer['fee']).to be_an(Integer)
     expect(transfer['multisig_txset']).to be_empty
     expect(transfer['tx_blob']).to be_empty


### PR DESCRIPTION
## Description
- Correct documentation for sending payments to multiple recipients
- Add note about test failing if balance not unlocked yet